### PR TITLE
update Dockerfile golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS src
+FROM golang:1.23 AS src
 
 WORKDIR /go/src/app/
 


### PR DESCRIPTION
Go mod is expecting go >= 1.23.0, however, the Dockerfile is only providing 1.22. Because of this, go mod download fails when running the compose file for go8. 