### PR TITLE
fix: sql unknown driver when using migration

### DIFF
--- a/third_party/database/sqlx.go
+++ b/third_party/database/sqlx.go
@@ -21,7 +21,7 @@ func NewSqlx(cfg config.Database) *sqlx.DB {
 	case "postgres", "pgx":
 		dsn = fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
 			cfg.Host, cfg.Port, cfg.User, cfg.Pass, cfg.Name)
-		cfg.Driver = "pgx"
+		cfg.Driver = "postgres"
 	case "mysql":
 		dsn = fmt.Sprintf("%s:%s@(%s:%d)/%s?parseTime=true",
 			cfg.User,


### PR DESCRIPTION
fix "sql: unknown driver "" (forgotten import?)"

reference: https://github.com/nhatthm/otelsql/blob/9e27d2dca9af361e81889f979e3fa8d92e34f22f/.github/workflows/pr.yaml#L198